### PR TITLE
Bugfix/loading indicator animation does not stop when hidden

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,10 +28,10 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation project(':loadingindicator')
-    kapt 'com.android.databinding:compiler:3.0.1'
+    kapt "com.android.databinding:compiler:$android_gradle_plugin_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.0'
+    ext.kotlin_version = '1.2.31'
+    ext.android_gradle_plugin_version = '3.1.2'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath "com.android.tools.build:gradle:$android_gradle_plugin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 06 17:41:19 CET 2017
+#Mon Apr 30 14:18:18 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/loadingindicator/build.gradle
+++ b/loadingindicator/build.gradle
@@ -34,10 +34,10 @@ dependencies {
 
     implementation 'com.android.support:appcompat-v7:26.1.0'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    kapt 'com.android.databinding:compiler:3.0.1'
+    kapt "com.android.databinding:compiler:$android_gradle_plugin_version"
 }
 repositories {
     mavenCentral()

--- a/loadingindicator/src/main/res/layout/layout_loading_indicator.xml
+++ b/loadingindicator/src/main/res/layout/layout_loading_indicator.xml
@@ -6,6 +6,7 @@
         <variable
             name="vm"
             type="io.stanwood.framework.loadingindicator.LoadingIndicatorViewModel"/>
+        <import type="android.text.TextUtils"/>
 
     </data>
 
@@ -45,7 +46,7 @@
                     android:onClick="@{vm::onClick}"
                     android:padding="16dp"
                     android:src="@drawable/ic_refresh_white_24dp"
-                    app:anim="@{!vm.isError ? @anim/progress_rotate : null}"/>
+                    app:anim="@{!vm.isError &amp;&amp; vm.isVisible ? @anim/progress_rotate : null}"/>
             </FrameLayout>
         </LinearLayout>
     </io.stanwood.framework.loadingindicator.LoadingIndicatorView>


### PR DESCRIPTION
This fixes a really ugly bug which caused the progress animation to continue to run even if the indicator was hidden causing constant load on the CPU.